### PR TITLE
Fix HTML sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ If you need a sitemap or list of all your middleman pages, then you create a **s
 <% root_url = data.sitemap.url %>
 <ul>
     <% sitemap.resources.each do |page| %>
-        <% if page.url =~ /\.html/ %>
+        <% if page.path =~ /\.html/ %>
             <li><a href="<%= "#{root_url}#{page.url}" %>"><%= "#{root_url}#{page.url}" %></a></li>
         <% end %>
     <% end %>

--- a/README.md
+++ b/README.md
@@ -46,10 +46,8 @@ If you need a sitemap or list of all your middleman pages, then you create a **s
 ```ruby
 <% root_url = data.sitemap.url %>
 <ul>
-    <% sitemap.resources.each do |page| %>
-        <% if page.path =~ /\.html/ %>
-            <li><a href="<%= "#{root_url}#{page.url}" %>"><%= "#{root_url}#{page.url}" %></a></li>
-        <% end %>
+    <% sitemap.resources.select{ |page| page.path =~ /\.html/ }.each do |page| %>
+        <li><a href="<%= "#{root_url}#{page.url}" %>"><%= "#{root_url}#{page.url}" %></a></li>
     <% end %>
 </ul>
 ```

--- a/sitemap.html.erb
+++ b/sitemap.html.erb
@@ -1,8 +1,6 @@
 <% root_url = data.sitemap.url %>
 <ul>
-    <% sitemap.resources.each do |page| %>
-        <% if page.url =~ /\.html/ %>
-            <li><a href="<%= "#{root_url}#{page.url}" %>"><%= "#{root_url}#{page.url}" %></a></li>
-        <% end %>
+    <% sitemap.resources.select{ |page| page.path =~ /\.html/ }.each do |page| %>
+        <li><a href="<%= "#{root_url}#{page.url}" %>"><%= "#{root_url}#{page.url}" %></a></li>
     <% end %>
 </ul>


### PR DESCRIPTION
We were using `page.url` instead of `page.path` to filter which resources should be printed as pages in the sitemap and this doesn't work. I just fix it and changed to the same approach used in `sitemap.xml.builder` (Use select instead of an additional if).

Please review it and merge!
